### PR TITLE
Expose parameter noiseStrength to user

### DIFF
--- a/BoolODE/__init__.py
+++ b/BoolODE/__init__.py
@@ -67,6 +67,7 @@ class BoolODE(object):
         Default parameter values are specified here.
         '''
         jobs = {}
+        experimental_settings = {'noise_strength':10}
         for jobid, job in enumerate(self.job_settings.jobs):
             data = {}
             # Create output folder if it doesnt exist
@@ -99,7 +100,15 @@ class BoolODE(object):
             data['add_dummy'] = job.get('add_dummy',False)
             data['max_parents'] = job.get('max_parents',1)
             data['modeltype'] = self.global_settings.modeltype
+            data['noise_strength'] = job.get('noise_strength', 10)
 
+            warnlist = [setting for setting in data.keys()\
+                        if (setting in experimental_settings.keys())\
+                        and (data[setting] != experimental_settings[setting])]
+            for ef in warnlist:
+                print(f"___WARNING___\ntIN JOB [{data['name']}] SETTING [{ef}: {data[ef]}]")
+                print(f"={ef}= is currently an experimental feature in BoolODE!")
+                print(f"Results obtained by varying this parameter are\nnot guaranteed to produce optimal results!")
             jobs[jobid] = data
         return(jobs)
 

--- a/BoolODE/run_experiment.py
+++ b/BoolODE/run_experiment.py
@@ -129,6 +129,7 @@ def Experiment(mg, Model,
     argdict['proteinIndex'] = proteinIndex
     argdict['revvarmapper'] = revvarmapper
     argdict['x_max'] = mg.kineticParameterDefaults['x_max']
+    argdict['noiseStrength'] = settings['noise_strength']
 
     if settings['sample_cells']:
         # pre-define the time points from which a cell will be sampled
@@ -297,6 +298,7 @@ def simulateAndSample(argdict):
     seed = argdict['seed']
     pars = argdict['pars']
     x_max = argdict['x_max']
+    noiseStrength = argdict['noiseStrength']
     
     # Retained for debugging
     isStochastic = True
@@ -324,7 +326,7 @@ def simulateAndSample(argdict):
                                      genelist, proteinlist,
                                      varmapper,revvarmapper)
         
-        P = simulator.simulateModel(Model, y0_exp, pars, isStochastic, tspan, seed)
+        P = simulator.simulateModel(Model, y0_exp, pars, isStochastic, tspan, seed, noiseStrength)
         P = P.T
         retry = False
         ## Extract Time points

--- a/config-files/example-config.yaml
+++ b/config-files/example-config.yaml
@@ -107,6 +107,11 @@ jobs:
     ## by a smaller threshold of activation. Specify the strength
     ## as a number between 1 and 20. (Max protein level=20)
     interaction_strengths: "dyn-linear_strengths.txt"
+
+    ################ EXPERIMENTAL FEATURES ################
+    ## Noise strength to use in stochastic simulations
+    # noise_strength: 10
+
     
 post_processing:
   ## Once the simulations have been performed, individual trajectories are


### PR DESCRIPTION
1. Replaces the hard-coded value of c=10 with the parameter
   noiseStrength in simulator.noise().
2. This parameter can now be set as a per-job setting specified
   by the user configuration file.
3. Adds a warning message if the parameter is encountered in the
   the config file and its value does not match the default, i.e. 10.
4. Update example-config.yaml with this option, but leave it commented
   out so people know that it is optional.